### PR TITLE
Tighten outcode regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "iojs"
+  - "5.0"
+  - "4.0"
   - "0.12"
   - "0.11"
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ postcode.sector()       // => "EC1V 9"
 postcode.unit()         // => "LB"
 ```
 
-Misc. Class Methods include
+### Method Overview
+
+| Postcode | .outcode() | .incode() | .area() | .district() | .subDistrict() | .sector() | .unit() |
+|----------|------------|-----------|---------|-------------|----------------|-----------|---------|
+| AA9A 9AA | AA9A       | 9AA       | AA      | AA9         | AA9A           | AA9A 9    | AA      |
+| A9A 9AA  | A9A        | 9AA       | A       | A9          | A9A            | A9A 9     | AA      |
+| A9 9AA   | A9         | 9AA       | A       | A9          | null           | A9 9      | AA      |
+| A99 9AA  | A99        | 9AA       | A       | A99         | null           | A99 9     | AA      |
+| AA9 9AA  | AA9        | 9AA       | AA      | AA9         | null           | AA9 9     | AA      |
+| AA99 9AA | AA99       | 9AA       | AA      | AA99        | null           | AA99 9    | AA      |
+
+### Misc. Class Methods include
 
 ```
 Postcode.validOutcode(outcode)
@@ -74,7 +85,7 @@ The postcode sector is made up of the postcode district, the single space, and t
 
 ### Unit
 
-The postcode unit is two characters added to the end of the postcode sector. Each postcode unit generally represents a street, part of a street, a single address, a group of properties, a single property, a sub-section of the property, an individual organisation or (for instance Driver and Vehicle Licensing Agency) a subsection of the organisation. The level of discrimination is often based on the amount of mail received by the premises or business. Examples of postcode units include "SW1W 0NY", "PO16 7GZ", "GU16 7HF", or "L1 8JQ".
+The postcode unit is two characters added to the end of the postcode sector. Each postcode unit generally represents a street, part of a street, a single address, a group of properties, a single property, a sub-section of the property, an individual organisation or (for instance Driver and Vehicle Licensing Agency) a subsection of the organisation. The level of discrimination is often based on the amount of mail received by the premises or business. Examples of postcode units include "NY" (from "SW1W 0NY"), "GZ" (from "PO16 7GZ"), "HF" (from "GU16 7HF"), or "JQ" (from "L1 8JQ").
 
 Sources:
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var validationRegex = /^[a-z]([a-z]\d[a-z]|\d[a-z]|\d|\d\d|[a-z]\d|[a-z]\d\d)\s*?\d[a-z]{2}$/i,
+var validationRegex = /^[a-z]{1,2}\d[a-z\d]?\s*?\d[a-z]{2}$/i,
 		incodeRegex = /\d[a-z]{2}$/i,
-		validOutcodeRegex = /^[a-z]([a-z]\d[a-z]|\d[a-z]|\d|\d\d|[a-z]\d|[a-z]\d\d)$/i,
+		validOutcodeRegex = /^[a-z]{1,2}\d[a-z\d]?$/i,
 		areaRegex = /^[a-z]{1,2}/i,
 		districtSplitRegex = /^([a-z]{1,2}\d)([a-z])$/i,
 		sectorRegex = /^[a-z][a-z\d]{1,3}\s*?\d/i,

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var validationRegex = /^[a-z][a-z\d]{1,3}\s*?\d[a-z]{2}$/i,
+var validationRegex = /^[a-z]([a-z]\d[a-z]|\d[a-z]|\d|\d\d|[a-z]\d|[a-z]\d\d)\s*?\d[a-z]{2}$/i,
 		incodeRegex = /\d[a-z]{2}$/i,
-		validOutcodeRegex = /^[a-z][a-z\d]{1,3}$/i,
+		validOutcodeRegex = /^[a-z]([a-z]\d[a-z]|\d[a-z]|\d|\d\d|[a-z]\d|[a-z]\d\d)$/i,
 		areaRegex = /^[a-z]{1,2}/i,
 		districtSplitRegex = /^([a-z]{1,2}\d)([a-z])$/i,
 		sectorRegex = /^[a-z][a-z\d]{1,3}\s*?\d/i,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var validationRegex = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i,
 		validOutcodeRegex = /^[a-z]{1,2}\d[a-z\d]?$/i,
 		areaRegex = /^[a-z]{1,2}/i,
 		districtSplitRegex = /^([a-z]{1,2}\d)([a-z])$/i,
-		sectorRegex = /^[a-z][a-z\d]{1,3}\s*\d/i,
+		sectorRegex = /^[a-z]{1,2}\d[a-z\d]?\s*\d/i,
 		unitRegex = /[a-z]{2}$/i;
 
 function isValidPostcode (postcode) {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var validationRegex = /^[a-z]{1,2}\d[a-z\d]?\s*?\d[a-z]{2}$/i,
+var validationRegex = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i,
 		incodeRegex = /\d[a-z]{2}$/i,
 		validOutcodeRegex = /^[a-z]{1,2}\d[a-z\d]?$/i,
 		areaRegex = /^[a-z]{1,2}/i,
 		districtSplitRegex = /^([a-z]{1,2}\d)([a-z])$/i,
-		sectorRegex = /^[a-z][a-z\d]{1,3}\s*?\d/i,
+		sectorRegex = /^[a-z][a-z\d]{1,3}\s*\d/i,
 		unitRegex = /[a-z]{2}$/i;
 
 function isValidPostcode (postcode) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcode",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "UK Postcode helper methods",
   "main": "index.js",
   "directories": {

--- a/tests/data/areas.json
+++ b/tests/data/areas.json
@@ -47,6 +47,54 @@
 		{
 			"base" : "BT358GE",
 			"expected" : "BT"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "A"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "A"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "A"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "A"
+		},
+		{
+			"base": "A99AA",
+			"expected": "A"
+		},
+		{
+			"base": "A999AA",
+			"expected": "A"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "AA"
 		}
 	]
 }

--- a/tests/data/districts.json
+++ b/tests/data/districts.json
@@ -63,6 +63,58 @@
 		{
 			"base" : "N1C 0AB",
 			"expected" : "N1"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "A99"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "AA99"
+		},
+		{
+			"base" : "N1C 0AB",
+			"expected" : "N1"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A99AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A999AA",
+			"expected": "A99"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "AA99"
 		}
 	]
 }

--- a/tests/data/incodes.json
+++ b/tests/data/incodes.json
@@ -47,6 +47,54 @@
 		{
 			"base" : "BT358GE",
 			"expected" : "8GE"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A99AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "A999AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "9AA"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "9AA"
 		}
 	]
 }

--- a/tests/data/outcodes.json
+++ b/tests/data/outcodes.json
@@ -47,6 +47,54 @@
 		{
 			"base" : "BT358GE",
 			"expected" : "BT35"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA9A"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "A9A"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "A99"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "AA99"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "AA9A"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "A9A"
+		},
+		{
+			"base": "A99AA",
+			"expected": "A9"
+		},
+		{
+			"base": "A999AA",
+			"expected": "A99"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "AA9"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "AA99"
 		}
 	]
 }

--- a/tests/data/sectors.json
+++ b/tests/data/sectors.json
@@ -47,6 +47,54 @@
 		{
 			"base" : "BT358GE",
 			"expected" : "BT35 8"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA9A 9"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "A9A 9"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "A9 9"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "A99 9"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "AA9 9"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "AA99 9"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "AA9A 9"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "A9A 9"
+		},
+		{
+			"base": "A99AA",
+			"expected": "A9 9"
+		},
+		{
+			"base": "A999AA",
+			"expected": "A99 9"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "AA9 9"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "AA99 9"
 		}
 	]
 }

--- a/tests/data/sub-districts.json
+++ b/tests/data/sub-districts.json
@@ -63,6 +63,30 @@
 		{
 			"base" : "N1C 0AB",
 			"expected" : "N1C"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA9A"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "A9A"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": null
+		},
+		{
+			"base": "A99 9AA",
+			"expected": null
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": null
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": null
 		}
 	]
 }

--- a/tests/data/units.json
+++ b/tests/data/units.json
@@ -47,6 +47,54 @@
 		{
 			"base" : "BT358GE",
 			"expected" : "GE"
+		},
+		{
+			"base": "AA9A 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A9A 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A9 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A99 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA9 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA99 9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA9A9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A9A9AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A99AA",
+			"expected": "AA"
+		},
+		{
+			"base": "A999AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA99AA",
+			"expected": "AA"
+		},
+		{
+			"base": "AA999AA",
+			"expected": "AA"
 		}
 	]
 }

--- a/tests/data/validation.json
+++ b/tests/data/validation.json
@@ -41,6 +41,14 @@
 			"expected" : false
 		},
 		{
+			"base" : "EH1JS",
+			"expected" : false
+		},
+		{
+			"base" : "EH 1JS",
+			"expected" : false
+		},
+		{
 			"base" : "BT35 8GE",
 			"expected" : true
 		}

--- a/tests/data/validation.json
+++ b/tests/data/validation.json
@@ -37,6 +37,10 @@
 			"expected" : true
 		},
 		{
+			"base" : "EH1 JS",
+			"expected" : false
+		},
+		{
 			"base" : "BT35 8GE",
 			"expected" : true
 		}


### PR DESCRIPTION
Potential fix for issue #7 by tightening regex

Outward codes currently can take the form:
- AA9A
- A9A
- A9
- A99
- AA9
- AA99

After eliminating the initial character, the new outcode regex tests specifically for each of those six cases with: `([a-z]\d[a-z] | \d[a-z] | \d | \d\d | [a-z]\d | [a-z]\d\d)` (spaces added for readability)
